### PR TITLE
fix untokenized option of new command

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -93,7 +93,7 @@ fn ask_add_field_text(field_name: &str, schema_builder: &mut SchemaBuilder) {
             }
         }
         else {
-            TextIndexingOptions::Unindexed
+            TextIndexingOptions::Untokenized
         }
     }
     else {


### PR DESCRIPTION
`tantivy new` doesn't output `untokenized` correctly for following answers:
```
New field name  ? a
Text or unsigned 32-bit integer (T/I) ? T
Should the field be stored (Y/N) ? Y
Should the field be indexed (Y/N) ? Y
Should the field be tokenized (Y/N) ? N
Add another field (Y/N) ? N

[
  {
    "name": "a",
    "type": "text",
    "options": {
      "indexing": "unindexed",
      "stored": true
    }
  }
]
```