### PR TITLE
Prevent panics when bad state is found - e.g. no meta.json or no indexing dir

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,1 @@
+error_chain!{}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,1 +1,0 @@
-error_chain!{}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ extern crate byteorder;
 #[macro_use]
 extern crate serde_derive;
 
-
 use clap::{AppSettings, Arg, App, SubCommand};
 mod commands;
 use self::commands::*;
@@ -137,5 +136,12 @@ fn main() {
         "bench" => run_bench_cli,
         _ => panic!("Subcommand {} is unknown", subcommand)
     };
-    run_cli(options).unwrap();
+
+    if let Err(ref e) = run_cli(options) {
+        use std::io::Write;
+        let stderr = &mut ::std::io::stderr();
+        let errmsg = "Error writing ot stderr";
+        writeln!(stderr, "{}", e).expect(errmsg);
+        ::std::process::exit(1);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ extern crate byteorder;
 #[macro_use]
 extern crate serde_derive;
 
+use std::io::Write;
+
 use clap::{AppSettings, Arg, App, SubCommand};
 mod commands;
 use self::commands::*;
@@ -138,10 +140,9 @@ fn main() {
     };
 
     if let Err(ref e) = run_cli(options) {
-        use std::io::Write;
-        let stderr = &mut ::std::io::stderr();
+        let stderr = &mut std::io::stderr();
         let errmsg = "Error writing ot stderr";
         writeln!(stderr, "{}", e).expect(errmsg);
-        ::std::process::exit(1);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
This fixes #21 and #22.