### PR TITLE
Trivial fixes to typo and redundant line

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -32,7 +32,6 @@ fn run_search(directory: &Path, query: &str) -> tantivy::Result<()> {
     let query = query_parser.parse_query(query)?;
     let searcher = index.reader()?.searcher();
     let weight = query.weight(&searcher, false)?;
-    let schema = index.schema();
     for segment_reader in searcher.segment_readers() {
         let mut scorer = weight.scorer(segment_reader, 1.0)?;
         let store_reader = segment_reader.get_store_reader();

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn main() {
 
     if let Err(ref e) = run_cli(options) {
         let stderr = &mut std::io::stderr();
-        let errmsg = "Error writing ot stderr";
+        let errmsg = "Error writing to stderr";
         writeln!(stderr, "{}", e).expect(errmsg);
         std::process::exit(1);
     }


### PR DESCRIPTION
Making a first pull request of trivial edits.

- Redundant `index.schema()` in `search.rs`
- Typo in `main.rs`