### PR TITLE
Swap println to writeln

### DIFF
--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -1,8 +1,10 @@
 use clap::ArgMatches;
 use serde_json;
 use std::convert::From;
+use std::io::{self, ErrorKind, Write};
 use std::path::Path;
 use std::path::PathBuf;
+use std::process;
 use tantivy;
 use tantivy::query::QueryParser;
 use tantivy::schema::Field;
@@ -32,6 +34,10 @@ fn run_search(directory: &Path, query: &str) -> tantivy::Result<()> {
     let query = query_parser.parse_query(query)?;
     let searcher = index.reader()?.searcher();
     let weight = query.weight(&searcher, false)?;
+
+    let stdout = io::stdout();
+    let mut handle = io::BufWriter::new(stdout);
+
     for segment_reader in searcher.segment_readers() {
         let mut scorer = weight.scorer(segment_reader, 1.0)?;
         let store_reader = segment_reader.get_store_reader();
@@ -39,9 +45,19 @@ fn run_search(directory: &Path, query: &str) -> tantivy::Result<()> {
             let doc_id = scorer.doc();
             let doc = store_reader.get(doc_id)?;
             let named_doc = schema.to_named_doc(&doc);
-            println!("{}", serde_json::to_string(&named_doc).unwrap());
+            if let Err(e) = writeln!(
+                handle,
+                "{}",
+                serde_json::to_string(&named_doc).unwrap()
+            ) {
+                if e.kind() != ErrorKind::BrokenPipe {
+                    eprintln!("{}", e.to_string());
+                    process::exit(1)
+                }
+            }
             scorer.advance();
         }
     }
     Ok(())
 }
+


### PR DESCRIPTION
PR to address #54. Swaps `println` for `writeln` and wraps the stdout in a `BufWriter`. I found the latter to add a minor performance improvement, although I’m not completely confident in I/O caching issues.

With 1M entries from the wikipedia sample database, I ran the following tests with hyperfine.

**Locked io::stdout**
```
$ hyperfine 'tantivy-cli/target/release/tantivy search -i wikipedia-index -q "the"'
Benchmark #1: tantivy-cli/target/release/tantivy search -i wikipedia-index -q "the"
  Time (mean ± σ):      9.870 s ±  0.083 s    [User: 9.374 s, System: 0.490 s]
  Range (min … max):    9.791 s … 10.072 s    10 runs


$ hyperfine 'tantivy-cli/target/release/tantivy search -i wikipedia-index -q "barack obama"'
Benchmark #1: tantivy-cli/target/release/tantivy search -i wikipedia-index -q "barack obama"
  Time (mean ± σ):     169.1 ms ±   7.8 ms    [User: 145.5 ms, System: 22.9 ms]
  Range (min … max):   163.9 ms … 193.1 ms    16 runs
 
  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

**Wrapping stdout with BufWriter**
```
$ hyperfine 'tantivy-cli/target/release/tantivy search -i wikipedia-index -q "the"'
Benchmark #1: tantivy-cli/target/release/tantivy search -i wikipedia-index -q "the"
  Time (mean ± σ):      9.137 s ±  0.035 s    [User: 8.954 s, System: 0.175 s]
  Range (min … max):    9.091 s …  9.193 s    10 runs


$ hyperfine 'tantivy-cli/target/release/tantivy search -i wikipedia-index -q "barack obama"'
Benchmark #1: tantivy-cli/target/release/tantivy search -i wikipedia-index -q "barack obama"
  Time (mean ± σ):     163.4 ms ±   0.5 ms    [User: 142.2 ms, System: 21.1 ms]
  Range (min … max):   162.5 ms … 164.6 ms    18 runs
```